### PR TITLE
Add minimum-stability to composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,7 @@
     "files": [
       "lib/Common/customFunctions.php"
     ]
-  }
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true
 }


### PR DESCRIPTION
```
Problem 1
    - Root composer.json requires pedrommone/php-qrcode-detector-decoder, it could not be found in any version, there may be a typo in the package name.

Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://getcomposer.org/doc/04-schema.md#minimum-stability> for more details.
 - It's a private package and you forgot to add a custom repository to find it
 ```